### PR TITLE
use virtualbox 5.2 api to get vbox

### DIFF
--- a/src/vm_list.py
+++ b/src/vm_list.py
@@ -8,7 +8,10 @@ try:
     from vboxapi import VirtualBoxManager
     from vboxapi.VirtualBox_constants import VirtualBoxReflectionInfo
     mgr = VirtualBoxManager(None, None)
-    vbox = mgr.vbox
+    try:
+        vbox = mgr.getVirtualBox()
+    except:
+        raise
     constants = VirtualBoxReflectionInfo(False)
     vbox_available = True
 except ImportError:

--- a/src/vm_list.py
+++ b/src/vm_list.py
@@ -8,10 +8,7 @@ try:
     from vboxapi import VirtualBoxManager
     from vboxapi.VirtualBox_constants import VirtualBoxReflectionInfo
     mgr = VirtualBoxManager(None, None)
-    try:
-        vbox = mgr.getVirtualBox()
-    except:
-        raise
+    vbox = mgr.getVirtualBox()
     constants = VirtualBoxReflectionInfo(False)
     vbox_available = True
 except ImportError:


### PR DESCRIPTION
should fix #11 .
In 5.1 api, they have
```python        
        try:
              self.vbox = self.platform.getVirtualBox()
```
in the init of VirtualBoxManager, but in 5.2, the `self` is missing, only vbox, I don't know why...